### PR TITLE
Added metafield functions

### DIFF
--- a/web/frontend/pages/Wallet.jsx
+++ b/web/frontend/pages/Wallet.jsx
@@ -39,7 +39,7 @@ export default function Wallet() {
   const activator = useRef(null);
 
   useEffect(() => {
-    authFetch("/api/auth-wallet", {
+    authFetch("/api/get-shop-data", {
       method: "GET",
       headers: { "Content-Type": "application/json" },
     }).then(async ({ body }) => {

--- a/web/index.js
+++ b/web/index.js
@@ -11,6 +11,7 @@ import { authenticate_wallet } from "./routes/auth.js";
 import "dotenv/config";
 import cors from "cors";
 import { getShopData } from "./utils/getShopDetails.js";
+import { createMetafield } from "./utils/metafield.js";
 
 const PORT = parseInt(
   process.env.BACKEND_PORT || process.env.PORT || "3000",
@@ -50,7 +51,16 @@ app.use(serveStatic(STATIC_PATH, { index: false }));
 app.get("/api/auth-wallet", authenticate_wallet);
 
 app.use("/api/get-shop-data", async (_req, res, _next) => {
-  const shopName = await getShopData(res.locals.shopify.session);
+  const session = res.locals.shopify.session;
+  const shopName = await getShopData(session);
+  const respons = await createMetafield(
+    session,
+    "$app:wallet",
+    "wallet_id",
+    "1",
+    "string",
+  );
+  console.log(respons);
 
   return res.status(200).send({
     data: shopName,

--- a/web/index.js
+++ b/web/index.js
@@ -11,7 +11,11 @@ import { authenticate_wallet } from "./routes/auth.js";
 import "dotenv/config";
 import cors from "cors";
 import { getShopData } from "./utils/getShopDetails.js";
-import { createMetafield, getMetafield } from "./utils/metafield.js";
+import {
+  createMetafield,
+  getMetafield,
+  deleteMetafield,
+} from "./utils/metafield.js";
 
 const PORT = parseInt(
   process.env.BACKEND_PORT || process.env.PORT || "3000",
@@ -53,7 +57,7 @@ app.get("/api/auth-wallet", authenticate_wallet);
 app.use("/api/get-shop-data", async (_req, res, _next) => {
   const session = res.locals.shopify.session;
   const shopName = await getShopData(session);
-  const respons = await getMetafield(session, "$app:wallet", "wallet_id");
+  const respons = await deleteMetafield(session, "$app:wallet", "wallet_id");
   console.log(respons);
 
   return res.status(200).send({

--- a/web/index.js
+++ b/web/index.js
@@ -11,7 +11,7 @@ import { authenticate_wallet } from "./routes/auth.js";
 import "dotenv/config";
 import cors from "cors";
 import { getShopData } from "./utils/getShopDetails.js";
-import { createMetafield } from "./utils/metafield.js";
+import { createMetafield, getMetafield } from "./utils/metafield.js";
 
 const PORT = parseInt(
   process.env.BACKEND_PORT || process.env.PORT || "3000",
@@ -53,13 +53,7 @@ app.get("/api/auth-wallet", authenticate_wallet);
 app.use("/api/get-shop-data", async (_req, res, _next) => {
   const session = res.locals.shopify.session;
   const shopName = await getShopData(session);
-  const respons = await createMetafield(
-    session,
-    "$app:wallet",
-    "wallet_id",
-    "1",
-    "string",
-  );
+  const respons = await getMetafield(session, "$app:wallet", "wallet_id");
   console.log(respons);
 
   return res.status(200).send({

--- a/web/index.js
+++ b/web/index.js
@@ -10,7 +10,7 @@ import { authenticate_wallet } from "./routes/auth.js";
 
 import "dotenv/config";
 import cors from "cors";
-import { getShopName } from "./utils/getShopDetails.js";
+import { getShopData } from "./utils/getShopDetails.js";
 
 const PORT = parseInt(
   process.env.BACKEND_PORT || process.env.PORT || "3000",
@@ -49,12 +49,10 @@ app.use(serveStatic(STATIC_PATH, { index: false }));
 
 app.get("/api/auth-wallet", authenticate_wallet);
 
-app.use("/api/get-shop-name", async (_req, res, _next) => {
-  const shopName = await getShopName(res.locals.shopify.session);
+app.use("/api/get-shop-data", async (_req, res, _next) => {
+  const shopName = await getShopData(res.locals.shopify.session);
 
   return res.status(200).send({
-    error: false,
-    message: "Test completed!",
     data: shopName,
   });
 });

--- a/web/utils/getShopDetails.js
+++ b/web/utils/getShopDetails.js
@@ -1,18 +1,10 @@
 import shopify from "../shopify.js";
 
 export const getShopName = async (session) => {
-  const query = `
-        {
-            shop {
-                name
-            }
-        }
-    `;
-
   try {
-    const client = new shopify.api.clients.Graphql({ session });
+    const client = new shopify.api.rest({ session });
 
-    const data = await client.query({ data: query });
+    const data = await client.get({ path: "shop" });
 
     return data.body;
   } catch (err) {

--- a/web/utils/getShopDetails.js
+++ b/web/utils/getShopDetails.js
@@ -1,13 +1,14 @@
 import shopify from "../shopify.js";
 
-export const getShopName = async (session) => {
+export const getShopData = async (session) => {
   try {
-    const client = new shopify.api.rest({ session });
+    const client = new shopify.api.clients.Rest({ session });
 
     const data = await client.get({ path: "shop" });
 
-    return data.body;
+    return data;
   } catch (err) {
+    console.error(err);
     return { error: err };
   }
 };

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -1,5 +1,27 @@
 import shopify from "../shopify.js";
 
+// ! func: getMetafield (3 params)
+// ? session: the session generated from Shopify OAuth
+// ? namespace: the namespace of the metafield
+// ? key: the key of the metafield
+// * CRUD type: get
+
+export async function getMetafield(session, namespace, key) {
+  try {
+    const res = await shopify.api.rest.Metafield.all({
+      session: session,
+      namespace: namespace,
+      key: key,
+    });
+
+    return res.data[0];
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}
+
+// post
 export async function createMetafield(session, namespace, key, value, type) {
   try {
     const metafield = new shopify.api.rest.Metafield({ session: session });
@@ -19,6 +41,7 @@ export async function createMetafield(session, namespace, key, value, type) {
   }
 }
 
+// put
 export async function updateMetafield(session, namespace, key, value, type) {
   try {
     const metafield = new shopify.api.rest.Metafield({ session: session });
@@ -38,17 +61,4 @@ export async function updateMetafield(session, namespace, key, value, type) {
   }
 }
 
-export async function getMetafield(session, namespace, key) {
-  try {
-    const res = await shopify.api.rest.Metafield.all({
-      session: session,
-      namespace: namespace,
-      key: key,
-    });
-
-    return res.data[0];
-  } catch (err) {
-    console.error(err);
-    return err;
-  }
-}
+// delete

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -78,6 +78,15 @@ export async function updateMetafield(session, namespace, key, value, type) {
   }
 }
 
+// ! func: updateMetafield (5 params)
+// ? session: the session generated from Shopify OAuth
+// ? namespace: the namespace of the metafield
+// ? key: the key of the metafield
+// ? value: the value of the metafield
+// ? type: the type of the metafield (json, string)
+// * CRUD type: put
+// * return value: Object[error: (false/Error)]
+
 export async function deleteMetafield(session, namespace, key) {
   try {
     const { id } = await getMetafield(session, namespace, key);

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -48,7 +48,14 @@ export async function createMetafield(session, namespace, key, value, type) {
   }
 }
 
-// put
+// ! func: updateMetafield (5 params)
+// ? session: the session generated from Shopify OAuth
+// ? namespace: the namespace of the metafield
+// ? key: the key of the metafield
+// ? value: the value of the metafield
+// ? type: the type of the metafield (json, string)
+// * CRUD type: put
+
 export async function updateMetafield(session, namespace, key, value, type) {
   try {
     const metafield = new shopify.api.rest.Metafield({ session: session });

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -9,6 +9,25 @@ export async function createMetafield(session, namespace, key, value, type) {
     metafield.type = type;
 
     const res = await metafield.save({
+      update: false,
+    });
+
+    return res;
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}
+
+export async function updateMetafield(session, namespace, key, value, type) {
+  try {
+    const metafield = new shopify.api.rest.Metafield({ session: session });
+    metafield.namespace = namespace;
+    metafield.key = key;
+    metafield.value = value;
+    metafield.type = type;
+
+    const res = await metafield.save({
       update: true,
     });
 

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -21,7 +21,14 @@ export async function getMetafield(session, namespace, key) {
   }
 }
 
-// post
+// ! func: createMetafield (5 params)
+// ? session: the session generated from Shopify OAuth
+// ? namespace: the namespace of the metafield
+// ? key: the key of the metafield
+// ? value: the value of the metafield
+// ? type: the type of the metafield (json, string)
+// * CRUD type: post
+
 export async function createMetafield(session, namespace, key, value, type) {
   try {
     const metafield = new shopify.api.rest.Metafield({ session: session });

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -79,11 +79,19 @@ export async function updateMetafield(session, namespace, key, value, type) {
 }
 
 export async function deleteMetafield(session, namespace, key) {
-  const { id } = await getMetafield(session, namespace, key);
+  try {
+    const { id } = await getMetafield(session, namespace, key);
 
-  await shopify.rest.Metafield.delete({
-    session: session,
-    blog_id: 382285388,
-    id: 534526895,
-  });
+    const res = await shopify.api.rest.Metafield.delete({
+      session: session,
+      id: id,
+    });
+
+    if (res == undefined) {
+      return { error: false };
+    }
+  } catch (err) {
+    console.error(err);
+    return { error: err };
+  }
 }

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -27,7 +27,7 @@ export async function getMetafield(session, namespace, key) {
       key: key,
     });
 
-    return res;
+    return res.data[0];
   } catch (err) {
     console.error(err);
     return err;

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -21,7 +21,7 @@ export async function createMetafield(session, namespace, key, value, type) {
 
 export async function getMetafield(session, namespace, key) {
   try {
-    const res = await shopify.rest.Metafield.all({
+    const res = await shopify.api.rest.Metafield.all({
       session: session,
       namespace: namespace,
       key: key,
@@ -29,7 +29,7 @@ export async function getMetafield(session, namespace, key) {
 
     return res;
   } catch (err) {
-    console.error(error);
-    return error;
+    console.error(err);
+    return err;
   }
 }

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -5,6 +5,7 @@ import shopify from "../shopify.js";
 // ? namespace: the namespace of the metafield
 // ? key: the key of the metafield
 // * CRUD type: get
+// * return value: Metafield[id, namespace, key, wallet_id, value, description, owner_id, created_at, updated_at, owner_resource, type, admin_graphql_api_id]
 
 export async function getMetafield(session, namespace, key) {
   try {
@@ -28,6 +29,7 @@ export async function getMetafield(session, namespace, key) {
 // ? value: the value of the metafield
 // ? type: the type of the metafield (json, string)
 // * CRUD type: post
+// * return value: undefined
 
 export async function createMetafield(session, namespace, key, value, type) {
   try {
@@ -55,6 +57,7 @@ export async function createMetafield(session, namespace, key, value, type) {
 // ? value: the value of the metafield
 // ? type: the type of the metafield (json, string)
 // * CRUD type: put
+// * return value: Metafield[id, namespace, key, wallet_id, value, description, owner_id, created_at, updated_at, owner_resource, type, admin_graphql_api_id]
 
 export async function updateMetafield(session, namespace, key, value, type) {
   try {
@@ -75,4 +78,12 @@ export async function updateMetafield(session, namespace, key, value, type) {
   }
 }
 
-// delete
+export async function deleteMetafield(session, namespace, key) {
+  const { id } = await getMetafield(session, namespace, key);
+
+  await shopify.rest.Metafield.delete({
+    session: session,
+    blog_id: 382285388,
+    id: 534526895,
+  });
+}

--- a/web/utils/metafield.js
+++ b/web/utils/metafield.js
@@ -1,0 +1,35 @@
+import shopify from "../shopify.js";
+
+export async function createMetafield(session, namespace, key, value, type) {
+  try {
+    const metafield = new shopify.api.rest.Metafield({ session: session });
+    metafield.namespace = namespace;
+    metafield.key = key;
+    metafield.value = value;
+    metafield.type = type;
+
+    const res = await metafield.save({
+      update: true,
+    });
+
+    return res;
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}
+
+export async function getMetafield(session, namespace, key) {
+  try {
+    const res = await shopify.rest.Metafield.all({
+      session: session,
+      namespace: namespace,
+      key: key,
+    });
+
+    return res;
+  } catch (err) {
+    console.error(error);
+    return error;
+  }
+}


### PR DESCRIPTION
## Describe the changes

Added functions to perform CRUD operations for metafields.

## What issues does this solve?

None, it's just useful for the API later on

## Does this add any dependencies

No.

## Any breaking changes

None.

### Any other comments

- There are 4 functions: `getMetafield`, `creategetMetafield`, `updateMetafield` and `deleteMetafield`
- Adding a `$app:` to a namespace makes it reserved to our app
- We started using the shopify REST api instead of GraphQL - so much better
- Please add comments to describe changes when changing the function
