### PR TITLE
Fixed #56. Add getCurrentUrl function for dynamic API URL retrieval.

### DIFF
--- a/extensions/greenstand-tokens-extension/UrlProvider.js
+++ b/extensions/greenstand-tokens-extension/UrlProvider.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const toml = require('toml');
+
+function getCurrentUrl() {
+    try {
+        // Get the path to shopify.app.toml in the root folder
+        const tomlFilePath = './shopify.app.toml';
+
+        // Read the contents of the TOML file
+        const tomlContent = fs.readFileSync(tomlFilePath, 'utf8');
+
+        // Parse the TOML content
+        const tomlObject = toml.parse(tomlContent);
+
+        // Extract the URL from the parsed TOML
+        const url = tomlObject.shopify.app.url;
+
+        return url;
+    } catch (error) {
+        // Handle any exceptions (e.g., file not found, invalid format)
+        console.error(`Error reading shopify.app.toml: ${error.message}`);
+        return null;
+    }
+}
+
+module.exports = getCurrentUrl;


### PR DESCRIPTION
Subject: Add getCurrentUrl function for dynamic API URL retrieval

Body:
- Added a new JavaScript file, `UrlProvider.js`, containing the `getCurrentUrl` function.
- The function reads the 'shopify.app.toml' file in the root folder and extracts the URL using the 'toml' library.
- Added error handling for cases such as file not found or invalid format.

Closes #56

## Describe the changes

[Describe changes here]

## What issues does this solve?

- [Add issues here]
- 

## Does this add any dependencies

[List dependencies added]

## Any breaking changes

[Breaking changes]

### Any other comments

[Comments]
